### PR TITLE
Dockerize app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:cli
+
+WORKDIR /app
+
+COPY ./h-m-m .
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+  libonig-dev xclip xsel wl-clipboard
+
+RUN docker-php-ext-install pcntl mbstring
+
+RUN chmod +x h-m-m
+
+CMD ["./h-m-m"]

--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,15 @@ In Linux, you need to have `xclip`, `xsel`, or `wl-clipboard` installed as well.
 
 In Arch Linux, you can use the `h-m-m-git` AUR package to install it.
 
+It's also possible to execute `h-m-m` through docker (or podman), just run:
+
+```sh
+# Build the image
+docker build -t hmm .
+
+# Run it
+docker run --rm -it -v $(pwd):/app/ hmm
+```
 
 # Troubleshooting
 


### PR DESCRIPTION
Hey, I've just created a Dockerfile and added instructions on how to execute it within a container.

As I'm not familiar with PHP tooling, I'm not sure if all those instructions on Dockerfile are really needed, please review it.

Also, I don't know if you want this feature added or not (feel free to reject this PR), but I like to run such tools in containers, so it would be great to have this option.

Very cool app btw