### PR TITLE
Dockerfile: Copy h-m-m to image as one of the final steps of the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,12 @@ FROM php:cli
 
 WORKDIR /app
 
-COPY ./h-m-m .
-
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
   libonig-dev xclip xsel wl-clipboard
 
 RUN docker-php-ext-install mbstring
 
-RUN chmod +x h-m-m
+COPY ./h-m-m .
 
 CMD ["./h-m-m"]


### PR DESCRIPTION
Each edit to the h-m-m script was triggering a full image rebuild, including the slow apt-get and docker-php-ext-install steps.

I figure that the h-m-m script itself is more likely to change than the system installs.

Moving the COPY to after those operations means that each time h-m-m changes, the `docker build` can use the cache for the slow operations, and just add a new layer for the COPY at the end.

Plus `chmod +x h-m-m` is unnecessary as h-m-m already has the executable bit set.