### PR TITLE
fix: remove bashism

### DIFF
--- a/h-m-m
+++ b/h-m-m
@@ -478,7 +478,7 @@ function check_the_available_clipboard_tool(&$mm)
 
 	// now, the main OS ;)
 
-	exec('command -v xclip xsel wl-copy klipper', $result);
+	exec('command -v xclip || command -v xsel || command -v wl-copy || command -v klipper', $result);
 	$tool = basename($result[0] ?? '');
 
 	if (trim($tool)==='')


### PR DESCRIPTION
h-m-m fails to start when `/bin/sh` is linked to [Dash](https://askubuntu.com/questions/976485/what-is-the-point-of-sh-being-linked-to-dash).

Giving multiple commands to the `command -v` command seems to be a Bash-specific feature.